### PR TITLE
respect hours in toAdjustedTime

### DIFF
--- a/frameaccurate/js/FrameAccurateControls.js
+++ b/frameaccurate/js/FrameAccurateControls.js
@@ -177,7 +177,8 @@ var SmpteTimestamp = /** @class */ (function () {
     SmpteTimestamp.prototype.toAdjustedTime = function () {
         // take dropped frames around every full minute (except for every 10minutes) into account
         if (this.assetDescription.framesDroppedAtFullMinute > 0) {
-            var framesToAdd = this.minutes - Math.floor(this.minutes / 10);
+            var totalMinutes = this.hours * 60 + this.minutes;
+            var framesToAdd = totalMinutes - Math.floor(totalMinutes / 10);
             framesToAdd *= this.assetDescription.framesDroppedAtFullMinute;
             this.addFrame(-framesToAdd, false);
         }

--- a/frameaccurate/js/FrameAccurateControls.ts
+++ b/frameaccurate/js/FrameAccurateControls.ts
@@ -245,7 +245,8 @@ class SmpteTimestamp {
   public toAdjustedTime(): number {
     // take dropped frames around every full minute (except for every 10minutes) into account
     if (this.assetDescription.framesDroppedAtFullMinute > 0) {
-      let framesToAdd = this.minutes - Math.floor(this.minutes / 10);
+      const totalMinutes = this.hours * 60 + this.minutes;
+      let framesToAdd = totalMinutes - Math.floor(totalMinutes / 10);
       framesToAdd *= this.assetDescription.framesDroppedAtFullMinute;
       this.addFrame(-framesToAdd, false);
     }


### PR DESCRIPTION
When calculating the adjusted time (for frame holes), only the current minutes were taken into account, the minutes for the current hour were ignored.
Now working with `const totalMinutes = this.hours * 60 + this.minutes` to be frameaccurate after the first hour.